### PR TITLE
Dev/be -  토큰 재발급 리팩터링

### DIFF
--- a/server/src/main/java/com/codemouse/salog/auth/controller/TokenController.java
+++ b/server/src/main/java/com/codemouse/salog/auth/controller/TokenController.java
@@ -2,6 +2,7 @@ package com.codemouse.salog.auth.controller;
 
 import com.codemouse.salog.auth.jwt.JwtTokenizer;
 import com.codemouse.salog.auth.utils.TokenBlackListService;
+import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import io.jsonwebtoken.Claims;
 import org.springframework.http.ResponseEntity;
@@ -14,11 +15,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 @RestController
+@AllArgsConstructor
 public class TokenController {
-    @Autowired
-    private JwtTokenizer jwtTokenizer;
-    @Autowired
-    private TokenBlackListService tokenBlackListService;
+    private final JwtTokenizer jwtTokenizer;
+    private final TokenBlackListService tokenBlackListService;
 
     @PostMapping("/refresh")
     public ResponseEntity<?> refresh(@RequestBody Map<String, String> payload) {

--- a/server/src/main/java/com/codemouse/salog/auth/controller/TokenController.java
+++ b/server/src/main/java/com/codemouse/salog/auth/controller/TokenController.java
@@ -3,15 +3,11 @@ package com.codemouse.salog.auth.controller;
 import com.codemouse.salog.auth.jwt.JwtTokenizer;
 import com.codemouse.salog.auth.utils.TokenBlackListService;
 import lombok.AllArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
-import io.jsonwebtoken.Claims;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Date;
-import java.util.HashMap;
 import java.util.Map;
 
 @RestController
@@ -26,26 +22,12 @@ public class TokenController {
 
         tokenBlackListService.isBlackListed(oldRefreshToken);
 
-        // 기존 Refresh 토큰의 유효성을 검사하고, 새로운 Access 토큰을 생성
-        String newAccessToken = jwtTokenizer.refreshToken(oldRefreshToken);
+        // 기존 Refresh 토큰의 유효성을 검사하고, 새로운 Access 토큰과 refresh 토큰을 생성
+        Map<String, String> tokens = jwtTokenizer.tokenReissue(oldRefreshToken);
 
-        // 기존 Refresh 토큰에서 클레임을 추출
-        Claims claims = jwtTokenizer.getClaims(oldRefreshToken, jwtTokenizer.encodeBase64SecretKey(jwtTokenizer.getSecretKey())).getBody();
-
-        // 새로운 Refresh 토큰을 생성
-        String subject = claims.getSubject();
-        Date expiration = jwtTokenizer.getTokenExpiration(jwtTokenizer.getRefreshTokenExpirationMinutes());
-        String base64EncodeSecretKey = jwtTokenizer.encodeBase64SecretKey(jwtTokenizer.getSecretKey());
-        String newRefreshToken = jwtTokenizer.generateRefreshToken(subject, expiration, base64EncodeSecretKey);
-
-
-        // 기존 Refresh 토큰을 블랙리스트에 추가합니다.
+        // 기존 Refresh 토큰을 블랙리스트에 추가
         tokenBlackListService.addToBlackList(oldRefreshToken);
 
-        // 새로 생성한 Access 토큰과 Refresh 토큰을 클라이언트에 보내줍니다.
-        Map<String, String> tokens = new HashMap<>();
-        tokens.put("accessToken", "Bearer " + newAccessToken);
-        tokens.put("refreshToken", newRefreshToken);
         return ResponseEntity.ok(tokens);
     }
 }

--- a/server/src/main/java/com/codemouse/salog/auth/jwt/JwtTokenizer.java
+++ b/server/src/main/java/com/codemouse/salog/auth/jwt/JwtTokenizer.java
@@ -1,6 +1,5 @@
 package com.codemouse.salog.auth.jwt;
 
-import com.codemouse.salog.auth.utils.CustomAuthorityUtils;
 import com.codemouse.salog.exception.BusinessLogicException;
 import com.codemouse.salog.exception.ExceptionCode;
 import com.codemouse.salog.members.entity.Member;
@@ -129,7 +128,7 @@ public class JwtTokenizer {
         return claims;
     }
 
-    public String refreshToken(String refreshToken) {
+    public Map<String, String> tokenReissue(String refreshToken) {
         // 리프레쉬 토큰 검증
         Claims claims;
         try {
@@ -152,6 +151,16 @@ public class JwtTokenizer {
 
         // 새로운 액세스 토큰 발급
         Date expiration = this.getTokenExpiration(this.accessTokenExpirationMinutes);
-        return this.generateAccessToken(newClaims, email, expiration, this.encodeBase64SecretKey(this.secretKey));
+        String newAccessToken = this.generateAccessToken(newClaims, email, expiration, this.encodeBase64SecretKey(this.secretKey));
+
+        // 새로운 리프레쉬 토큰 발급
+        expiration = this.getTokenExpiration(this.refreshTokenExpirationMinutes);
+        String newRefreshToken = this.generateRefreshToken(email,expiration, this.encodeBase64SecretKey(this.secretKey));
+
+        Map<String, String> tokens = new HashMap<>();
+        tokens.put("accessToken", "Bearer " + newAccessToken);
+        tokens.put("refreshToken", newRefreshToken);
+
+        return tokens;
     }
 }

--- a/server/src/main/java/com/codemouse/salog/auth/utils/TokenBlackListService.java
+++ b/server/src/main/java/com/codemouse/salog/auth/utils/TokenBlackListService.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 // 로그아웃 - 토큰 블랙리스트 처리
+// todo-2023-12-19 현재 모든 컨트롤러와 결합도가 높아, 인터셉터 혹은 필터를 활용해 선 검증을 거치도록 리펙터링 해야함
 @Component
 public class TokenBlackListService {
     private Set<String> blackList = new HashSet<>();

--- a/server/src/main/java/com/codemouse/salog/members/controller/MemberController.java
+++ b/server/src/main/java/com/codemouse/salog/members/controller/MemberController.java
@@ -59,8 +59,8 @@ public class MemberController {
 
     @GetMapping("/get")
     public ResponseEntity getMember(@RequestHeader(name = "Authorization") String token) {
-        MemberDto.Response response = memberService.findMember(token);
         tokenBlackListService.isBlackListed(token);
+        MemberDto.Response response = memberService.findMember(token);
         return new ResponseEntity<>(
                 new SingleResponseDto<>(response), HttpStatus.OK);
     }
@@ -127,6 +127,7 @@ public class MemberController {
         }
     }
 
+    // todo 2023-12-20 로그아웃 시 토큰 블랙리스트에 리프레쉬도 추가해야함 (리프레쉬 탈취 방지)
     // 로그아웃
     @PostMapping("/logout")
     public String logout(@RequestHeader (name="Authorization") String token) {


### PR DESCRIPTION
### PR 타입

1. [ ] 기능 추가
2. [ ] 기능 삭제
3. [ ] 버그 수정
4. [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
5. [x] 리팩터링

### 변경 사항
컨트롤러와 토크나이저의 책임 분리

기존에는 컨트롤러에 리프레쉬 토큰 재발급 로직이 섞여있었다면
토큰에 대한 검증, 생성 처리는 전부 jwtTokenizer가 책임을 지게끔 변경함

토큰 컨트롤러에는 블랙리스트 검증과 통신에 대한 책임만 있음
단, 추후 로그아웃 리팩터링 과정을 거치게되면 컨트롤러는 통신의 책임만 지게 됨

이외 앞으로 진행할 리팩터링 todo 작성, 오타 수정, 불필요한 임포트 삭제

### 테스트 결과
O