### PR TITLE
feat/fix : 일기태그 유효성 검사 추가/ 일기 태그,제목검색 버그수정

### DIFF
--- a/server/src/main/java/com/codemouse/salog/diary/controller/DiaryController.java
+++ b/server/src/main/java/com/codemouse/salog/diary/controller/DiaryController.java
@@ -63,12 +63,8 @@ public class DiaryController {
                                         @Valid @RequestParam(required = false) String diaryTag,
                                         @Positive @RequestParam(required = false) Integer month,
                                         @RequestParam(required = false) String date){
-        // UTF-8로 디코딩
-        String decodedTag = URLDecoder.decode(diaryTag, StandardCharsets.UTF_8);
-        log.info("#DecodedTag To UTF-8 : {}", decodedTag);
-
         MultiResponseDto<DiaryDto.Response> pageDiaries =
-                diaryService.findAllDiaries(token, page, size, decodedTag, month, date);
+                diaryService.findAllDiaries(token, page, size, diaryTag, month, date);
 
         return new ResponseEntity<>(pageDiaries, HttpStatus.OK);
     }
@@ -79,12 +75,9 @@ public class DiaryController {
                                           @Positive @RequestParam int page,
                                           @Positive @RequestParam int size,
                                           @Valid @RequestParam String title){
-        // UTF-8로 디코딩
-        String decodedTitle = URLDecoder.decode(title, StandardCharsets.UTF_8);
-        log.info("#DecodedTitle To UTF-8 : {}", decodedTitle);
 
         MultiResponseDto<DiaryDto.Response> pageDiaries =
-                diaryService.findTitleDiaries(token, page, size, decodedTitle);
+                diaryService.findTitleDiaries(token, page, size, title);
 
         return new ResponseEntity<>(pageDiaries, HttpStatus.OK);
     }

--- a/server/src/main/java/com/codemouse/salog/diary/service/DiaryService.java
+++ b/server/src/main/java/com/codemouse/salog/diary/service/DiaryService.java
@@ -18,16 +18,21 @@ import com.codemouse.salog.tags.mapper.TagMapper;
 import com.codemouse.salog.tags.repository.DiaryTagLinkRepository;
 import com.codemouse.salog.tags.service.TagService;
 import lombok.AllArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Validator;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -38,6 +43,8 @@ public class DiaryService {
     private final DiaryMapper diaryMapper;
     private final TagService tagService;
     private final TagMapper tagMapper;
+    @Autowired
+    private final Validator validator; // 일기태그 유효성 검사
     private final DiaryTagLinkRepository diaryTagLinkRepository;
     private final JwtTokenizer jwtTokenizer;
     private final TokenBlackListService tokenBlackListService;
@@ -73,6 +80,13 @@ public class DiaryService {
             } else {
                 // 새 태그 생성
                 TagDto.DiaryPost diaryPost = new TagDto.DiaryPost(tagName);
+
+                // 추가: diaryPost에 대한 유효성 검사
+                Set<ConstraintViolation<TagDto.DiaryPost>> violations = validator.validate(diaryPost);
+                if (!violations.isEmpty()) {
+                    throw new BusinessLogicException(ExceptionCode.TAG_UNVALIDATED);
+                }
+
                 diaryTagToUse = tagService.postDiaryTag(token, diaryPost);
             }
             createdDiaryTags.add(diaryTagToUse);
@@ -110,8 +124,6 @@ public class DiaryService {
 
             // 새로운 태그 생성 및 연결
             for(String tagName : diaryDto.getTagList()) {
-                TagDto.DiaryPost diaryPost = new TagDto.DiaryPost(tagName);
-
                 // 기존 태그 검색
                 DiaryTag existingDiaryTag = tagService.findDiaryTagByMemberIdAndTagName(token, tagName);
 
@@ -121,6 +133,14 @@ public class DiaryService {
                     diaryTagToUse = existingDiaryTag;
                 } else {
                     // 새 태그 생성
+                    TagDto.DiaryPost diaryPost = new TagDto.DiaryPost(tagName);
+
+                    // 추가: diaryPost에 대한 유효성 검사
+                    Set<ConstraintViolation<TagDto.DiaryPost>> violations = validator.validate(diaryPost);
+                    if (!violations.isEmpty()) {
+                        throw new BusinessLogicException(ExceptionCode.TAG_UNVALIDATED);
+                    }
+
                     diaryTagToUse = tagService.postDiaryTag(token, diaryPost);
                 }
                 DiaryTagLink link = new DiaryTagLink();

--- a/server/src/main/java/com/codemouse/salog/diary/service/DiaryService.java
+++ b/server/src/main/java/com/codemouse/salog/diary/service/DiaryService.java
@@ -18,6 +18,7 @@ import com.codemouse.salog.tags.mapper.TagMapper;
 import com.codemouse.salog.tags.repository.DiaryTagLinkRepository;
 import com.codemouse.salog.tags.service.TagService;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -26,8 +27,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
 import javax.validation.Validator;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +37,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @Transactional
 @AllArgsConstructor
@@ -187,8 +190,12 @@ public class DiaryService {
 
         // 1. Only diaryTag에 대한 쿼리
         if (diaryTag != null && month == null && date == null) {
+            // UTF-8로 디코딩
+            String decodedTag = URLDecoder.decode(diaryTag, StandardCharsets.UTF_8);
+            log.info("DecodedTag To UTF-8 : {}", decodedTag);
+
             List<DiaryTagLink> diaryTagLinks = diaryTagLinkRepository.findByDiaryTagTagNameAndDiaryTagMember(
-                    diaryTag, memberService.findVerifiedMember(memberId));
+                    decodedTag, memberService.findVerifiedMember(memberId));
             List<Long> diaryIds = diaryTagLinks.stream()
                     .map(DiaryTagLink::getDiary)
                     .map(Diary::getDiaryId)
@@ -241,8 +248,12 @@ public class DiaryService {
         tokenBlackListService.isBlackListed(token); // 로그아웃 된 회원인지 체크
         long memberId = jwtTokenizer.getMemberId(token);
 
+        // UTF-8로 디코딩
+        String decodedTitle = URLDecoder.decode(title, StandardCharsets.UTF_8);
+        log.info("DecodedTitle To UTF-8 : {}", decodedTitle);
+
         // page 정보 생성
-        Page<Diary> diaryPage = diaryRepository.findAllByMemberMemberIdAndTitleContaining(memberId,title,
+        Page<Diary> diaryPage = diaryRepository.findAllByMemberMemberIdAndTitleContaining(memberId, decodedTitle,
                 PageRequest.of(page -1, size, Sort.by("date").descending()));
 
         List<DiaryDto.Response> diaryDtoList = diaryPage.getContent().stream()

--- a/server/src/main/java/com/codemouse/salog/exception/ExceptionCode.java
+++ b/server/src/main/java/com/codemouse/salog/exception/ExceptionCode.java
@@ -23,7 +23,9 @@ public enum ExceptionCode {
     MEMBER_MISMATCHED(400, "MEMBER_MISMATCHED MemberId가 일치하지 않음"),
     DIARY_NOT_FOUND(404, "DIARY_NOT_FOUND 존재하지 않는 일기"),
     DIARY_MISMATCHED(400, "DIARY_MISMATCHED DiaryId가 일치하지 않음"),
-    TAG_MISMATCHED(400, "TAG_MISMATCHED TagId가 일치하지 않음");
+    TAG_MISMATCHED(400, "TAG_MISMATCHED TagId가 일치하지 않음"),
+    TAG_UNVALIDATED(400, "TAG_UNVALIDATED 유효하지않은 태그, 10글자이내로 입력바람");
+
 
     private int status;
 

--- a/server/src/main/java/com/codemouse/salog/tags/dto/TagDto.java
+++ b/server/src/main/java/com/codemouse/salog/tags/dto/TagDto.java
@@ -3,11 +3,14 @@ package com.codemouse.salog.tags.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import javax.validation.constraints.Pattern;
+
 
 public class TagDto {
     @AllArgsConstructor
     @Getter
     public static class DiaryPost {
+        @Pattern(regexp = "^.{1,10}$")
         private String tagName;
     }
 


### PR DESCRIPTION
### PR 타입

1. [x] 기능 추가
2. [ ] 기능 삭제
3. [x] 버그 수정
4. [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
1. 일기태그 유효성 검사 로직 추가
2. 일기 태그, 제목 검색시 들어오는 null값에 대한 UTF-8 디코딩 조건 수정
3. UTF-8 디코딩로직 컨트롤러 -> 서비스로 이동   

### 테스트 결과
양호

### 특이 사항
- 일기 post시 받는 태그리스트는 따로 유효성검사를 해주려면 커스텀어노테이션 정의가 필요했지만
복잡성이 증가하기 때문에 태그생성 로직에 유효성검사로직만 추가해주는 방향으로 선정했습니다.
 -> 추후 비슷한 사례가 많이 생길 경우 커스텀어노테이션에 대해 추가하는 방향으로 생각 중입니다. 

- 3번 사유는 컨트롤러 로직보단 서비스쪽에 더 부합하다고 생각했기 때문입니다.