### PR TITLE
!HOTFIX : 회원 로그인 시 에러 리턴 분기 (상세하게)

### DIFF
--- a/server/src/main/java/com/codemouse/salog/auth/handler/MemberAuthenticationFailureHandler.java
+++ b/server/src/main/java/com/codemouse/salog/auth/handler/MemberAuthenticationFailureHandler.java
@@ -1,16 +1,21 @@
 package com.codemouse.salog.auth.handler;
 
+import com.codemouse.salog.exception.BusinessLogicException;
+import com.codemouse.salog.exception.ExceptionCode;
 import com.codemouse.salog.response.ErrorResponse;
 import com.google.gson.Gson;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 @Slf4j
 public class MemberAuthenticationFailureHandler implements AuthenticationFailureHandler {
@@ -21,12 +26,18 @@ public class MemberAuthenticationFailureHandler implements AuthenticationFailure
         // 인증 실패 시, 에러 로그를 기록하거나 error response를 전송할 수 있다.
         log.error("# Authentication failed: {}", exception.getMessage());
 
-        sendErrorResponse(response);
+        if (exception instanceof BadCredentialsException) {
+            // 비밀번호가 잘못된 경우
+            sendErrorResponse(response, ExceptionCode.PASSWORD_MISMATCHED);
+        } else {
+            sendErrorResponse(response, ExceptionCode.MEMBER_NOT_FOUND);
+        }
     }
 
-    private void sendErrorResponse(HttpServletResponse response) throws IOException{
+    private void sendErrorResponse(HttpServletResponse response, ExceptionCode exceptionCode) throws IOException{
         Gson gson = new Gson();
-        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.UNAUTHORIZED);
+        ErrorResponse errorResponse = ErrorResponse.of(exceptionCode);
+        response.setCharacterEncoding("UTF-8"); // 한글 인코딩
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setStatus(HttpStatus.UNAUTHORIZED.value());
         response.getWriter().write(gson.toJson(errorResponse, ErrorResponse.class));


### PR DESCRIPTION
### PR 타입

1. [x] 기능 추가
2. [ ] 기능 삭제
3. [ ] 버그 수정
4. [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
MemberAuthenticationFailureHandler 클래스에서 실패 시 리턴하는 응답 분기함
1. 크레덴셜 정보 틀렸을 경우
2. 이외의 모든 에러   
이메일이 틀린 경우 MemberDetailsServcie에서 loadUserByUsername 메서드 실행 시 회원을 찾지 못해 BusinessLoginException이 스프링 시큐리티 기본 보안 예외인 UsernameNotFoundException 보다 먼저 throw 되게끔 되어 있기 때문에 조건만 분기함

추가적으로 리스폰스 바디에 한글이 들어가기 때문에 인코딩해줌

### 테스트 결과
O