### PR TITLE
!HOTFIX : 수입, 지출 태그 동일 이름 시 충돌 에러 핸들링

### DIFF
--- a/server/src/main/java/com/codemouse/salog/ledger/income/service/IncomeService.java
+++ b/server/src/main/java/com/codemouse/salog/ledger/income/service/IncomeService.java
@@ -144,7 +144,7 @@ public class IncomeService {
         if (incomePostDto != null) {
             String tagName = incomePostDto;
 
-            LedgerTag existTag = tagService.findLedgerTagByMemberIdAndTagName(token, tagName);
+            LedgerTag existTag = tagService.findLedgerTagByMemberIdAndTagName(token, tagName, LedgerTag.Group.INCOME);
 
             if (existTag != null) {
                 if (existTag.getCategory() == LedgerTag.Group.INCOME) {

--- a/server/src/main/java/com/codemouse/salog/ledger/outgo/service/OutgoService.java
+++ b/server/src/main/java/com/codemouse/salog/ledger/outgo/service/OutgoService.java
@@ -167,7 +167,7 @@ public class OutgoService {
         if (outgoPostDto != null) {
             String tagName = outgoPostDto;
 
-            LedgerTag existTag = ledgerTagService.findLedgerTagByMemberIdAndTagName(token, tagName);
+            LedgerTag existTag = ledgerTagService.findLedgerTagByMemberIdAndTagName(token, tagName, LedgerTag.Group.OUTGO);
 
             if (existTag != null) {
                 if (existTag.getCategory() == LedgerTag.Group.OUTGO) {

--- a/server/src/main/java/com/codemouse/salog/tags/ledgerTags/repository/LedgerTagRepository.java
+++ b/server/src/main/java/com/codemouse/salog/tags/ledgerTags/repository/LedgerTagRepository.java
@@ -10,6 +10,6 @@ public interface LedgerTagRepository extends JpaRepository<LedgerTag, Long> {
     List<LedgerTag> findAllByMemberMemberIdAndCategory(Long memberId, LedgerTag.Group category);
 
     // memberId와 tagName에 맞는 태그 찾기
-    LedgerTag findByMemberMemberIdAndTagName(long memberId, String tagName);
+    LedgerTag findByMemberMemberIdAndTagNameAndCategory(long memberId, String tagName, LedgerTag.Group category);
     List<LedgerTag> findAllByMemberMemberIdAndTagName(long memberId, String tagName);
 }

--- a/server/src/main/java/com/codemouse/salog/tags/ledgerTags/service/LedgerTagService.java
+++ b/server/src/main/java/com/codemouse/salog/tags/ledgerTags/service/LedgerTagService.java
@@ -80,10 +80,10 @@ public class LedgerTagService {
     }
 
     // 멤버와 태그이름에 해당하는 객체
-    public LedgerTag findLedgerTagByMemberIdAndTagName(String token, String tagName){
+    public LedgerTag findLedgerTagByMemberIdAndTagName(String token, String tagName, LedgerTag.Group category){
         long memberId = jwtTokenizer.getMemberId(token);
 
-        return ledgerTagRepository.findByMemberMemberIdAndTagName(memberId, tagName);
+        return ledgerTagRepository.findByMemberMemberIdAndTagNameAndCategory(memberId, tagName, category);
     }
 
     // 잉여태그 삭제


### PR DESCRIPTION
### PR 타입

1. [ ] 기능 추가
2. [ ] 기능 삭제
3. [x] 버그 수정
4. [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
수입, 지출 등록 시 동일 태그 이름 에러 발생 수정
tagHandler 중복 체크 시 쿼리에서 category를 나누어 연산 가능하게 변경
tagRepository에서 관련 쿼리 메서드명 변경

### 테스트 결과
O