### PR TITLE
Feat : 월별 예산 구현 완료 / 수입 통계 수정

### DIFF
--- a/server/src/main/java/com/codemouse/salog/ledger/budget/dto/BudgetDto.java
+++ b/server/src/main/java/com/codemouse/salog/ledger/budget/dto/BudgetDto.java
@@ -28,7 +28,7 @@ public class BudgetDto {
         private long budgetId;
         private LocalDate date;
         private long budget;
-        private int totalOutgo; // 지출 월별 합계 계산 (비교를 위함)
+        private long totalOutgo; // 지출 월별 합계 계산 (비교를 위함)
         private int dayRemain;
     }
 }

--- a/server/src/main/java/com/codemouse/salog/ledger/income/repository/IncomeRepository.java
+++ b/server/src/main/java/com/codemouse/salog/ledger/income/repository/IncomeRepository.java
@@ -27,7 +27,7 @@ public interface IncomeRepository extends JpaRepository<Income, Long> {
     @Query("SELECT SUM(i.money) FROM Income i WHERE i.member.memberId = :memberId AND YEAR(i.date) = :year AND MONTH(i.date) = :month")
     Long findTotalIncomeByMonth(@Param("memberId") long memberId, @Param("year") int year, @Param("month") int month);
 
-    @Query("SELECT i.ledgerTag.tagName, SUM(i.money) FROM Income i WHERE i.member.memberId = :memberId AND YEAR(i.date) = :year AND MONTH(i.date) = :month GROUP BY i.ledgerTag.tagName")
+    @Query("SELECT i.ledgerTag.tagName, SUM(i.money) FROM Income i WHERE i.member.memberId = :memberId AND YEAR(i.date) = :year AND MONTH(i.date) = :month AND i.ledgerTag.category = 'INCOME' GROUP BY i.ledgerTag.tagName")
     List<Object[]> findTotalIncomeByMonthGroupByTag(@Param("memberId") long memberId, @Param("year") int year, @Param("month") int month);
 
     long countByLedgerTag(LedgerTag ledgerTag);

--- a/server/src/main/java/com/codemouse/salog/ledger/income/service/IncomeService.java
+++ b/server/src/main/java/com/codemouse/salog/ledger/income/service/IncomeService.java
@@ -117,9 +117,10 @@ public class IncomeService {
 
         // 월별 태그 합계 계산
         List<Object[]> totalIncomeByTag = incomeRepository.findTotalIncomeByMonthGroupByTag(memberId, year, month);
+
         // 계산된 태그 합계를 삽입
         List<LedgerTagDto.MonthlyResponse> tagIncomes = totalIncomeByTag.stream()
-                .map(obj -> new LedgerTagDto.MonthlyResponse((String) obj[0], (Long) obj[1]))
+                .map(obj -> new LedgerTagDto.MonthlyResponse((String) obj[0], obj[1] != null ? (Long) obj[1] : 0))
                 .collect(Collectors.toList());
 
         // 월별 수입 합계 계산

--- a/server/src/main/java/com/codemouse/salog/ledger/outgo/repository/OutgoRepository.java
+++ b/server/src/main/java/com/codemouse/salog/ledger/outgo/repository/OutgoRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -37,6 +38,9 @@ public interface OutgoRepository extends JpaRepository<Outgo, Long> {
             "WHERE o.member_id = :memberId AND YEAR(o.date) = :year AND MONTH(o.date) = :month AND lt.category = 'OUTGO' AND waste_list = TRUE " +
             "GROUP BY lt.ledger_tag_id, lt.tag_name", nativeQuery = true)
     List<Object[]> getSumOfWasteListsByTag(Long memberId, int year, int month);
+
+    @Query("SELECT SUM(o.money) FROM Outgo o WHERE o.member.memberId = :memberId AND YEAR(o.date) = :year AND MONTH(o.date) = :month")
+    Long findTotalOutgoByMonth(@Param("memberId") long memberId, @Param("year") int year, @Param("month") int month);
 
     long countByLedgerTag(LedgerTag ledgerTag);
 }


### PR DESCRIPTION
### PR 타입

1. [x] 기능 추가
2. [ ] 기능 삭제
3. [ ] 버그 수정
4. [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
월별 예산에 월별 지출 합계 대입 완료 / 값이 없을 경우 에러 리턴 대신 0을 대입하도록 변경
수입 월별 합계 중 태그 계산 시 category 로우가 INCOME 인 경우만 리턴하도록 변경 (필터링)
데이터 정합성을 위해 예산 dto 중 total outgo 타입을 long으로 변경

### 테스트 결과
O