### PR TITLE
feat : 캘린더 조회 구현

### DIFF
--- a/server/src/main/java/com/codemouse/salog/ledger/calendar/controller/CalendarController.java
+++ b/server/src/main/java/com/codemouse/salog/ledger/calendar/controller/CalendarController.java
@@ -1,0 +1,33 @@
+package com.codemouse.salog.ledger.calendar.controller;
+
+import com.codemouse.salog.auth.utils.TokenBlackListService;
+import com.codemouse.salog.ledger.calendar.dto.CalendarDto;
+import com.codemouse.salog.ledger.calendar.service.CalendarService;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.List;
+
+@RestController
+@Slf4j
+@Validated
+@AllArgsConstructor
+@RequestMapping("/calendar")
+public class CalendarController {
+    private final CalendarService calendarService;
+    private final TokenBlackListService tokenBlackListService;
+
+    @GetMapping
+    public ResponseEntity<?> getCalendar(@RequestHeader(name = "Authorization") String token,
+                                         @Valid @RequestParam String date){
+        tokenBlackListService.isBlackListed(token);
+        List<CalendarDto.Response> responses = calendarService.getCalendar(token, date);
+
+        return new ResponseEntity<>(responses, HttpStatus.OK);
+    }
+}

--- a/server/src/main/java/com/codemouse/salog/ledger/calendar/dto/CalendarDto.java
+++ b/server/src/main/java/com/codemouse/salog/ledger/calendar/dto/CalendarDto.java
@@ -1,0 +1,15 @@
+package com.codemouse.salog.ledger.calendar.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class CalendarDto {
+    @AllArgsConstructor
+    @Getter
+    public static class Response {
+        private String date;
+        private long totalOutgo;
+        private long totalIncome;
+    }
+}

--- a/server/src/main/java/com/codemouse/salog/ledger/calendar/service/CalendarService.java
+++ b/server/src/main/java/com/codemouse/salog/ledger/calendar/service/CalendarService.java
@@ -1,0 +1,45 @@
+package com.codemouse.salog.ledger.calendar.service;
+
+import com.codemouse.salog.auth.jwt.JwtTokenizer;
+import com.codemouse.salog.ledger.calendar.dto.CalendarDto;
+import com.codemouse.salog.ledger.income.repository.IncomeRepository;
+import com.codemouse.salog.ledger.income.service.IncomeService;
+import com.codemouse.salog.ledger.outgo.repository.OutgoRepository;
+import com.codemouse.salog.ledger.outgo.service.OutgoService;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional
+@Slf4j
+@AllArgsConstructor
+public class CalendarService {
+    private final IncomeService incomeService;
+    private final OutgoService outgoService;
+
+    public List<CalendarDto.Response> getCalendar(String token, String date){
+        List<CalendarDto.Response> responses = new ArrayList<>();
+
+        LocalDate parsedDate = LocalDate.parse(date.substring(0, 7) + "-01");
+        LocalDate startDate = parsedDate.withDayOfMonth(1);
+        LocalDate endDate = parsedDate.withDayOfMonth(parsedDate.lengthOfMonth());
+
+        // 해당 월의 모든 날짜를 순회
+        for (LocalDate curDate = startDate; !curDate.isAfter(endDate); curDate = curDate.plusDays(1)) {
+            // 날짜별로 totalOutgo와 totalIncome을 조회
+            long totalOutgo = outgoService.getDailyTotalOutgo(token, curDate);
+            long totalIncome = incomeService.getDailyTotalIncome(token, curDate);
+
+            // CalendarDto.Response 객체를 생성하고 리스트에 추가
+            responses.add(new CalendarDto.Response(curDate.toString(), totalOutgo, totalIncome));
+        }
+
+        return responses;
+    }
+}

--- a/server/src/main/java/com/codemouse/salog/ledger/income/repository/IncomeRepository.java
+++ b/server/src/main/java/com/codemouse/salog/ledger/income/repository/IncomeRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface IncomeRepository extends JpaRepository<Income, Long> {
@@ -29,6 +30,9 @@ public interface IncomeRepository extends JpaRepository<Income, Long> {
 
     @Query("SELECT i.ledgerTag.tagName, SUM(i.money) FROM Income i WHERE i.member.memberId = :memberId AND YEAR(i.date) = :year AND MONTH(i.date) = :month AND i.ledgerTag.category = 'INCOME' GROUP BY i.ledgerTag.tagName")
     List<Object[]> findTotalIncomeByMonthGroupByTag(@Param("memberId") long memberId, @Param("year") int year, @Param("month") int month);
+
+    @Query("SELECT SUM(i.money) FROM Income i WHERE i.member.memberId = :memberId AND i.date = :curDate")
+    Long findTotalIncomeByDay(long memberId, LocalDate curDate);
 
     long countByLedgerTag(LedgerTag ledgerTag);
 }

--- a/server/src/main/java/com/codemouse/salog/ledger/income/service/IncomeService.java
+++ b/server/src/main/java/com/codemouse/salog/ledger/income/service/IncomeService.java
@@ -26,6 +26,7 @@ import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -156,6 +157,14 @@ public class IncomeService {
                 .orElseThrow(
                         () -> new BusinessLogicException(ExceptionCode.INCOME_NOT_FOUND)
                 );
+    }
+
+    public long getDailyTotalIncome(String token, LocalDate curDate){
+        long memberId = jwtTokenizer.getMemberId(token);
+
+        return Optional.ofNullable(
+                incomeRepository.findTotalIncomeByDay(memberId, curDate)
+                ).orElse(0L); // 쿼리결과 null 값이 반환될 경우 0이 대신 반환
     }
 
     // 태그 등록, 중복 체크

--- a/server/src/main/java/com/codemouse/salog/ledger/outgo/repository/OutgoRepository.java
+++ b/server/src/main/java/com/codemouse/salog/ledger/outgo/repository/OutgoRepository.java
@@ -42,5 +42,8 @@ public interface OutgoRepository extends JpaRepository<Outgo, Long> {
     @Query("SELECT SUM(o.money) FROM Outgo o WHERE o.member.memberId = :memberId AND YEAR(o.date) = :year AND MONTH(o.date) = :month")
     Long findTotalOutgoByMonth(@Param("memberId") long memberId, @Param("year") int year, @Param("month") int month);
 
+    @Query("SELECT SUM(o.money) FROM Outgo o WHERE o.member.memberId = :memberId AND o.date = :curDate")
+    Long findTotalOutgoByDay(long memberId, LocalDate curDate);
+
     long countByLedgerTag(LedgerTag ledgerTag);
 }

--- a/server/src/main/java/com/codemouse/salog/ledger/outgo/service/OutgoService.java
+++ b/server/src/main/java/com/codemouse/salog/ledger/outgo/service/OutgoService.java
@@ -186,6 +186,14 @@ public class OutgoService {
                 () -> new BusinessLogicException(ExceptionCode.OUTGO_NOT_FOUND));
     }
 
+    public long getDailyTotalOutgo(String token, LocalDate curDate){
+        long memberId = jwtTokenizer.getMemberId(token);
+
+        return Optional.ofNullable(
+                outgoRepository.findTotalOutgoByDay(memberId, curDate)
+        ).orElse(0L); // 쿼리결과 null 값이 반환될 경우 0이 대신 반환
+    }
+
     // 태그 등록, 중복 체크
     private void tagHandler(String outgoPostDto, String token, Outgo outgo) {
         LedgerTag ledgerTag = null;


### PR DESCRIPTION
### PR 타입

1. [x] 기능 추가
2. [ ] 기능 삭제
3. [ ] 버그 수정
4. [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- income, outgoRepo 에 일별 금액합계 쿼리 추가
- income, outgoService 에 일별 금액합계를 반환해주는 메서드 추가
- 캘린더 패키지 및 컨트롤러, 서비스, dto 추가

### 특이 사항
- 캘린더에서 직접 repo에 접근하여 데이터를 생성하기보다 각 서비스로직에서 메서드를 생성하는 방식 채용함.

### 테스트 결과
- 양호