### PR TITLE
!HOTFIX : 일기 삭제 오류 수정

### DIFF
--- a/server/src/main/java/com/codemouse/salog/diary/service/DiaryService.java
+++ b/server/src/main/java/com/codemouse/salog/diary/service/DiaryService.java
@@ -295,6 +295,8 @@ public class DiaryService {
                 tagService.deleteDiaryTag(token ,diaryTag.getDiaryTagId());
             }
         }
+        // 중간 테이블의 레코드를 삭제
+        diaryTagLinkRepository.deleteByDiaryId(diaryId);
 
         diaryRepository.deleteById(diaryId);
     }

--- a/server/src/main/java/com/codemouse/salog/tags/diaryTags/repository/DiaryTagLinkRepository.java
+++ b/server/src/main/java/com/codemouse/salog/tags/diaryTags/repository/DiaryTagLinkRepository.java
@@ -4,10 +4,19 @@ import com.codemouse.salog.members.entity.Member;
 import com.codemouse.salog.tags.diaryTags.entity.DiaryTag;
 import com.codemouse.salog.tags.diaryTags.entity.DiaryTagLink;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 public interface DiaryTagLinkRepository extends JpaRepository<DiaryTagLink, Long> {
     List<DiaryTagLink> findByDiaryTagTagNameAndDiaryTagMember(String tagName, Member member);
     Long countByDiaryTag(DiaryTag diaryTag);
+
+    @Transactional
+    @Modifying // update나 delete는 해당 어노테이션을 추가해줘야함. (@Query만 사용할 경우 기본 select)
+    @Query("DELETE FROM DiaryTagLink d WHERE d.diary.diaryId = :diaryId")
+    void deleteByDiaryId(@Param("diaryId") Long diaryId);
 }


### PR DESCRIPTION
### PR 타입

1. [ ] 기능 추가
2. [ ] 기능 삭제
3. [x] 버그 수정
4. [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 여러 일기를 참조하는 태그가 존재할 경우, 해당 태그를 참조하는 일기가 삭제되지 않는 현상 수정
- 일기 삭제시 중간테이블 먼저 삭제하는 로직 추가
(mysql 환경에서 다대다 cascade조건이 무효하고 부모의 레코드 삭제전  자식의 레코드 삭제를 먼저 확인한 후 삭제하기 때문에
외래키 제약조건이 위반되었었음, 데이터 무결성을 지키기 위함.)

### 테스트 결과
- 양호