### PR TITLE
feat : diaryTagList 조회 시 일기 개수 필드 추가

### DIFF
--- a/server/src/main/java/com/codemouse/salog/tags/diaryTags/controller/DiaryTagController.java
+++ b/server/src/main/java/com/codemouse/salog/tags/diaryTags/controller/DiaryTagController.java
@@ -22,9 +22,9 @@ public class DiaryTagController {
     private final DiaryTagService service;
 
     @GetMapping("/diaryTags")
-    public ResponseEntity getAllDiaryTags (@RequestHeader(name = "Authorization") String token){
-        List<DiaryTagDto.Response> response = service.getAllDiaryTagList(token);
+    public ResponseEntity<?> getAllDiaryTags (@RequestHeader(name = "Authorization") String token){
+        List<DiaryTagDto.ResponseTagList> response = service.getAllDiaryTagList(token);
 
-        return new ResponseEntity<>(new SingleResponseDto<>(response), HttpStatus.OK);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/server/src/main/java/com/codemouse/salog/tags/diaryTags/dto/DiaryTagDto.java
+++ b/server/src/main/java/com/codemouse/salog/tags/diaryTags/dto/DiaryTagDto.java
@@ -17,7 +17,15 @@ public class DiaryTagDto {
     @AllArgsConstructor
     @Getter
     public static class Response {
-        private Long diaryTagId;
+        private long diaryTagId;
         private String tagName;
+    }
+
+    @AllArgsConstructor
+    @Getter
+    public static class ResponseTagList {
+        private long diaryTagId;
+        private String tagName;
+        private int diaryCount;
     }
 }

--- a/server/src/main/java/com/codemouse/salog/tags/diaryTags/repository/DiaryTagLinkRepository.java
+++ b/server/src/main/java/com/codemouse/salog/tags/diaryTags/repository/DiaryTagLinkRepository.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 public interface DiaryTagLinkRepository extends JpaRepository<DiaryTagLink, Long> {
     List<DiaryTagLink> findByDiaryTagTagNameAndDiaryTagMember(String tagName, Member member);
-    Long countByDiaryTag(DiaryTag diaryTag);
+    int countByDiaryTag(DiaryTag diaryTag);
 
     @Transactional
     @Modifying // update나 delete는 해당 어노테이션을 추가해줘야함. (@Query만 사용할 경우 기본 select)

--- a/server/src/main/java/com/codemouse/salog/tags/diaryTags/service/DiaryTagService.java
+++ b/server/src/main/java/com/codemouse/salog/tags/diaryTags/service/DiaryTagService.java
@@ -46,14 +46,17 @@ public class DiaryTagService {
     }
 
     // All DiaryTagList
-    public List<DiaryTagDto.Response> getAllDiaryTagList(String token){
+    public List<DiaryTagDto.ResponseTagList> getAllDiaryTagList(String token){
         tokenBlackListService.isBlackListed(token); // 로그아웃 된 회원인지 체크
         long memberId = jwtTokenizer.getMemberId(token);
         List<DiaryTag> diaryTags = diaryTagRepository.findAllByMemberMemberId(memberId);
 
-        List<DiaryTagDto.Response> tagList = new ArrayList<>();
+        List<DiaryTagDto.ResponseTagList> tagList = new ArrayList<>();
         for (DiaryTag diaryTag : diaryTags) {
-            DiaryTagDto.Response tagDto = mapper.DiaryTagToDiaryTagResponseDto(diaryTag);
+            int diaryCount = diaryTagLinkRepository.countByDiaryTag(diaryTag);
+            DiaryTagDto.ResponseTagList tagDto = new DiaryTagDto.ResponseTagList(
+                    diaryTag.getDiaryTagId(), diaryTag.getTagName(), diaryCount);
+
             tagList.add(tagDto);
         }
 
@@ -81,7 +84,7 @@ public class DiaryTagService {
 
         for (DiaryTag tag : allTags) {
             // 태그와 연결된 다이어리 개수 조회
-            long diaryCount = diaryTagLinkRepository.countByDiaryTag(tag);
+            int diaryCount = diaryTagLinkRepository.countByDiaryTag(tag);
 
             if (diaryCount == 0) {
                 // 다이어리와 연결점이 없는 경우 태그 삭제


### PR DESCRIPTION
### PR 타입

1. [x] 기능 추가
2. [ ] 기능 삭제
3. [ ] 버그 수정
4. [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- Dto.ResponseTagList 내부 클래스 추가 (기존 Response를 사용하던 다른 로직에도 영향이 가기 때문에 새로 만듬)
- 
- Dto.Response 의 diaryTagId 타입 변경 (래퍼클래스가 불필요하다 생각되어, long타입으로 변경)
- 
- diaryTagLink 중간테이블 레포지토리 쿼리 응답 타입 변경 (일기 갯수를 카운트하는데 long타입은 불필요 -> int)

### 테스트 결과
- 양호
