### PR TITLE
feat : 정책 변경으로 인한 수입/지출 수정 시 메모 컴포넌트 null 값 허용

### DIFF
--- a/server/src/main/java/com/codemouse/salog/ledger/income/service/IncomeService.java
+++ b/server/src/main/java/com/codemouse/salog/ledger/income/service/IncomeService.java
@@ -65,7 +65,7 @@ public class IncomeService {
                 .ifPresent(findIncome::setMoney);
         Optional.of(income.getIncomeName())
                 .ifPresent(findIncome::setIncomeName);
-        Optional.of(income.getMemo())
+        Optional.ofNullable(income.getMemo())
                 .ifPresent(findIncome::setMemo);
 
         // 태그

--- a/server/src/main/java/com/codemouse/salog/ledger/outgo/service/OutgoService.java
+++ b/server/src/main/java/com/codemouse/salog/ledger/outgo/service/OutgoService.java
@@ -71,7 +71,7 @@ public class OutgoService {
         Optional.of(outgo.getOutgoName()).ifPresent(findOutgo::setOutgoName);
         Optional.of(outgo.getMoney()).ifPresent(findOutgo::setMoney);
         Optional.of(outgo.getPayment()).ifPresent(findOutgo::setPayment);
-        Optional.of(outgo.getMemo()).ifPresent(findOutgo::setMemo);
+        Optional.ofNullable(outgo.getMemo()).ifPresent(findOutgo::setMemo);
         Optional.of(outgo.getReceiptImg()).ifPresent(findOutgo::setReceiptImg);
         Optional.of(outgo.isWasteList()).ifPresent(findOutgo::setWasteList);
 


### PR DESCRIPTION
### PR 타입

1. [x] 기능 변경
2. [ ] 기능 삭제
3. [ ] 버그 수정
4. [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
어제 회의에 나온 수입/지출 수정 시에 메모에 null 값 허용하도록 Option 클래스의 of 메소드 사용을 ofnullable 메소드 사용으로 변경

### 테스트 결과
O