### PR TITLE
feat : diaryCalendar 조회 기능 추가, diary Delete 버그 수정 및 일부 리팩토링

### DIFF
--- a/server/src/main/java/com/codemouse/salog/diary/controller/DiaryController.java
+++ b/server/src/main/java/com/codemouse/salog/diary/controller/DiaryController.java
@@ -4,6 +4,7 @@ import com.codemouse.salog.diary.dto.DiaryDto;
 import com.codemouse.salog.diary.service.DiaryService;
 import com.codemouse.salog.dto.MultiResponseDto;
 import com.codemouse.salog.dto.SingleResponseDto;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,21 +13,14 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Positive;
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 
 @RestController
 @RequestMapping("/diary")
 @Validated
+@AllArgsConstructor
 @Slf4j
 public class DiaryController {
     private final DiaryService diaryService;
-
-    public DiaryController(DiaryService diaryService) {
-        this.diaryService = diaryService;
-    }
-
 
     // post
     @PostMapping("/post")
@@ -47,31 +41,29 @@ public class DiaryController {
 
     // get
     @GetMapping("/{diary-id}")
-    public ResponseEntity getDiary (@RequestHeader(name = "Authorization") String token,
+    public ResponseEntity<?> getDiary (@RequestHeader(name = "Authorization") String token,
                                     @PathVariable("diary-id") @Positive long diaryId){
         DiaryDto.Response response = diaryService.findDiary(token, diaryId);
 
-        return new ResponseEntity<>(
-                new SingleResponseDto<>(response), HttpStatus.OK);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
     // total list get
     @GetMapping
-    public ResponseEntity getAllDiaries (@RequestHeader(name = "Authorization") String token,
+    public ResponseEntity<?> getAllDiaries (@RequestHeader(name = "Authorization") String token,
                                         @Positive @RequestParam int page,
                                         @Positive @RequestParam int size,
                                         @Valid @RequestParam(required = false) String diaryTag,
-                                        @Positive @RequestParam(required = false) Integer month,
                                         @RequestParam(required = false) String date){
         MultiResponseDto<DiaryDto.Response> pageDiaries =
-                diaryService.findAllDiaries(token, page, size, diaryTag, month, date);
+                diaryService.findAllDiaries(token, page, size, diaryTag, date);
 
         return new ResponseEntity<>(pageDiaries, HttpStatus.OK);
     }
 
     // title list get
     @GetMapping("/search")
-    public ResponseEntity getTitleDiaries (@RequestHeader(name = "Authorization") String token,
+    public ResponseEntity<?> getTitleDiaries (@RequestHeader(name = "Authorization") String token,
                                           @Positive @RequestParam int page,
                                           @Positive @RequestParam int size,
                                           @Valid @RequestParam String title){

--- a/server/src/main/java/com/codemouse/salog/diary/controller/DiaryController.java
+++ b/server/src/main/java/com/codemouse/salog/diary/controller/DiaryController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Positive;
+import java.util.List;
 
 @RestController
 @RequestMapping("/diary")
@@ -72,6 +73,15 @@ public class DiaryController {
                 diaryService.findTitleDiaries(token, page, size, title);
 
         return new ResponseEntity<>(pageDiaries, HttpStatus.OK);
+    }
+
+    // diaryCalendar get
+    @GetMapping("/calendar")
+    public ResponseEntity<?> getDiaryCalendar(@RequestHeader(name = "Authorization") String token,
+                                              @RequestParam String date){
+        List<DiaryDto.ResponseCalender> response = diaryService.getDiaryCalendar(token, date);
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
     // delete

--- a/server/src/main/java/com/codemouse/salog/diary/dto/DiaryDto.java
+++ b/server/src/main/java/com/codemouse/salog/diary/dto/DiaryDto.java
@@ -44,4 +44,11 @@ public class DiaryDto {
         private String img;
         private List<DiaryTagDto.Response> tagList;
     }
+
+    @AllArgsConstructor
+    @Getter
+    @Setter
+    public static class ResponseCalender {
+        private LocalDate date;
+    }
 }

--- a/server/src/main/java/com/codemouse/salog/diary/repository/DiaryRepository.java
+++ b/server/src/main/java/com/codemouse/salog/diary/repository/DiaryRepository.java
@@ -13,9 +13,10 @@ import java.util.List;
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
     Page<Diary> findAllByMemberMemberId(long memberId, Pageable pageRequest);
     Page<Diary> findAllByDiaryIdIn(List<Long> diaryIds, Pageable pageable);
-    @Query("SELECT d FROM Diary d WHERE d.member.id = :memberId AND EXTRACT(MONTH FROM d.date) = :month")
-    Page<Diary> findAllByMonth(@Param("memberId") Long memberId, @Param("month") Integer month, Pageable pageable);
+
     Page<Diary> findAllByMemberMemberIdAndDate(Long memberId, LocalDate date, Pageable pageable);
-    Page<Diary> findAllByMemberMemberIdAndTitleContaining(long memberId, String title,
-                                                          Pageable pageRequest);
+    Page<Diary> findAllByMemberMemberIdAndTitleContaining(long memberId, String title, Pageable pageRequest);
+
+    @Query("SELECT DISTINCT d.date FROM Diary d WHERE d.member.id = :memberId AND YEAR(d.date) = :year AND MONTH(d.date) = :month")
+    List<LocalDate> findDistinctDatesByMemberIdAndYearAndMonth(@Param("memberId") Long memberId, @Param("year") int year, @Param("month") int month);
 }

--- a/server/src/main/java/com/codemouse/salog/diary/service/DiaryService.java
+++ b/server/src/main/java/com/codemouse/salog/diary/service/DiaryService.java
@@ -31,6 +31,7 @@ import javax.validation.Validator;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -269,6 +270,24 @@ public class DiaryService {
                 .collect(Collectors.toList());
 
         return new MultiResponseDto<>(diaryDtoList, diaryPage);
+    }
+
+    // Get Diary Calendar
+    public List<DiaryDto.ResponseCalender> getDiaryCalendar(String token, String date){
+        tokenBlackListService.isBlackListed(token);
+        long memberId = jwtTokenizer.getMemberId(token);
+
+        String[] dateParts = date.split("-");
+        int year = Integer.parseInt(dateParts[0]);
+        int month = Integer.parseInt(dateParts[1]);
+
+        // 해당 '년'과 '월'에 대한 일기의 날짜만을 가져옴, 중복제거
+        List<LocalDate> dates = diaryRepository.findDistinctDatesByMemberIdAndYearAndMonth(memberId, year, month);
+
+        // 결과를 DiaryDto.ResponseCalender 객체의 리스트로 변환
+        return dates.stream()
+                .map(DiaryDto.ResponseCalender::new)
+                .collect(Collectors.toList());
     }
 
     // delete

--- a/server/src/main/java/com/codemouse/salog/tags/diaryTags/repository/DiaryTagLinkRepository.java
+++ b/server/src/main/java/com/codemouse/salog/tags/diaryTags/repository/DiaryTagLinkRepository.java
@@ -14,9 +14,4 @@ import java.util.List;
 public interface DiaryTagLinkRepository extends JpaRepository<DiaryTagLink, Long> {
     List<DiaryTagLink> findByDiaryTagTagNameAndDiaryTagMember(String tagName, Member member);
     int countByDiaryTag(DiaryTag diaryTag);
-
-    @Transactional
-    @Modifying // update나 delete는 해당 어노테이션을 추가해줘야함. (@Query만 사용할 경우 기본 select)
-    @Query("DELETE FROM DiaryTagLink d WHERE d.diary.diaryId = :diaryId")
-    void deleteByDiaryId(@Param("diaryId") Long diaryId);
 }

--- a/server/src/main/java/com/codemouse/salog/tags/diaryTags/service/DiaryTagService.java
+++ b/server/src/main/java/com/codemouse/salog/tags/diaryTags/service/DiaryTagService.java
@@ -39,8 +39,8 @@ public class DiaryTagService {
 
     // Diary Delete
     public void deleteDiaryTag(String token, Long diaryTagId) {
-        Member member = memberService.findVerifiedMember(jwtTokenizer.getMemberId(token));
-        DiaryTag diaryTag = findVerifiedDiaryTag(diaryTagId);
+        memberService.findVerifiedMember(jwtTokenizer.getMemberId(token));
+        findVerifiedDiaryTag(diaryTagId);
 
         diaryTagRepository.deleteById(diaryTagId);
     }


### PR DESCRIPTION
### PR 타입

1. [x] 기능 추가
2. [x] 기능 삭제
3. [x] 버그 수정
4. [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항 
1. 일기 캘린더 조회 기능 추가
2. service의 patch 메서드 수정
3. service의 getDiaryList 월별 조회 로직 삭제 및 수정
4. 일기 관련 가독성을 해치는 코드들 리팩토링 및 삭제
5. 일기 삭제 안되는 버그 수정

## 특이사항
1. 일기 캘린더 기능 추가로 인한 dto, controller, service 추가

2. diaryService 에서 mapStruct를 사용하지 않고 직접 치환해주던 방식은 타입 안정성을 해칠 수 있으므로, 
매퍼를 통한 dto 변환으로 수정함.

3. diaryService 전체조회시 월별 조회의 미사용으로 인한 로직 삭제

4. 가독성을 해치거나, 불필요해진 코드 삭제 및 리팩토링

5. 일기 삭제가 안되는 현상 발견 후 즉시 수정함
 >> 이전에 발생한 일기 삭제 로직과 관련된 문제는 하나의 일기가 참조하고 있는 태그를 삭제하려 할 때, 관련된 중간 테이블의 레코드가 삭제되지 않아 무결성 제약 조건에 위반되는 문제였습니다. 이로 인해 데이터 무결성에 관한 오류가 발생하였습니다.
그러나 이번에는 여러 일기가 동일한 태그를 참조하고 있을 경우, 해당 일기를 참조하고 있는 중간 테이블의 레코드를 삭제하려고 할 때 문제가 발생했습니다. 중간 테이블의 여러 레코드를 동시에 삭제하려고 하면 ObjectOptimisticLockingFailureException 예외가 발생합니다.
이 문제를 해결하기 위해, 반복문을 사용하여 중간 테이블의 레코드를 한 번에 하나씩만 삭제하도록 로직을 수정하였습니다. 이렇게 하면 ObjectOptimisticLockingFailureException 예외를 방지하고, 여러 일기가 동일한 태그를 참조하고 있을 때에도 일기를 안전하게 삭제할 수 있습니다

### 테스트 결과
- 양호