### PR TITLE
feat : 캘린더 수입지출 통합조회 기능 추가

### DIFF
--- a/server/src/main/java/com/codemouse/salog/ledger/calendar/controller/CalendarController.java
+++ b/server/src/main/java/com/codemouse/salog/ledger/calendar/controller/CalendarController.java
@@ -1,6 +1,7 @@
 package com.codemouse.salog.ledger.calendar.controller;
 
 import com.codemouse.salog.auth.utils.TokenBlackListService;
+import com.codemouse.salog.dto.MultiResponseDto;
 import com.codemouse.salog.ledger.calendar.dto.CalendarDto;
 import com.codemouse.salog.ledger.calendar.service.CalendarService;
 import lombok.AllArgsConstructor;
@@ -11,6 +12,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Positive;
 import java.util.List;
 
 @RestController
@@ -27,6 +29,18 @@ public class CalendarController {
                                          @Valid @RequestParam String date){
         tokenBlackListService.isBlackListed(token);
         List<CalendarDto.Response> responses = calendarService.getCalendar(token, date);
+
+        return new ResponseEntity<>(responses, HttpStatus.OK);
+    }
+
+    @GetMapping("/ledger")
+    public ResponseEntity<?> getIntegratedLedger(@RequestHeader(name = "Authorization") String token,
+                                                 @Positive @RequestParam int page,
+                                                 @Positive @RequestParam int size,
+                                                 @Valid @RequestParam String date,
+                                                 @Valid @RequestParam(required = false) String ledgerTag){
+        tokenBlackListService.isBlackListed(token);
+        MultiResponseDto<CalendarDto.LedgerResponse> responses = calendarService.getIntegratedLedger(token, page, size, date, ledgerTag);
 
         return new ResponseEntity<>(responses, HttpStatus.OK);
     }

--- a/server/src/main/java/com/codemouse/salog/ledger/calendar/dto/CalendarDto.java
+++ b/server/src/main/java/com/codemouse/salog/ledger/calendar/dto/CalendarDto.java
@@ -1,8 +1,11 @@
 package com.codemouse.salog.ledger.calendar.dto;
 
 
+import com.codemouse.salog.tags.ledgerTags.dto.LedgerTagDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
+import java.time.LocalDate;
 
 public class CalendarDto {
     @AllArgsConstructor
@@ -11,5 +14,20 @@ public class CalendarDto {
         private String date;
         private long totalOutgo;
         private long totalIncome;
+    }
+
+    @AllArgsConstructor
+    @Getter
+    public static class LedgerResponse {    // 통합조회 응답 Dto
+        private Long incomeId;
+        private Long outgoId;
+        private LocalDate date;
+        private int money;
+        private String ledgerName;  // 거래처
+        private String payment;
+        private String memo;
+        private LedgerTagDto.Response ledgerTag;    // 카테고리
+        private Boolean wasteList;
+        private String receiptImg;
     }
 }

--- a/server/src/main/java/com/codemouse/salog/ledger/outgo/service/OutgoService.java
+++ b/server/src/main/java/com/codemouse/salog/ledger/outgo/service/OutgoService.java
@@ -278,4 +278,12 @@ public class OutgoService {
 
         return outgoPage;
     }
+    
+    // 상단의 페이지생성 메서드오버로딩
+    public List<OutgoDto.Response> findOutgoPagesAsList(String token, int page, int size, String date, String outgoTag, Boolean isWasteList){
+        Page<Outgo> outgoPage = findOutgoPages(token, page, size, date, outgoTag, isWasteList);
+        return outgoPage.getContent().stream()
+                .map(outgoMapper::OutgoToOutgoResponseDto)
+                .collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
### PR 타입

1. [x] 기능 추가
2. [ ] 기능 삭제
3. [ ] 버그 수정
4. [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- outgo와 income 각 서비스 레이어에서 조회한 정보를 합쳐 calendarDto에 재배열, 날짜별로 내림차순 재정렬 후 응답
- outgoService 에서 반환 타입 변경을 위한 메서드 오버로딩

### 테스트 결과
- 양호