### PR TITLE
톰캣 서버 실행 불가 문제 해결을 위해 키스토어 파일을 컨테이너 내부로 복사

### DIFF
--- a/server/dockerfile
+++ b/server/dockerfile
@@ -1,5 +1,6 @@
 # Package stage
 FROM openjdk:11-jre-slim
 COPY ./server/build/libs/salog-0.0.1-SNAPSHOT.jar /app/salog.jar
+COPY /home/ec2-user/keystore.p12 /app/keystore.p12
 EXPOSE 8080
 ENTRYPOINT ["java","-jar","/app/salog.jar"]


### PR DESCRIPTION
톰캣 서버 실행 불가 문제 해결을 위해 키스토어 파일을 컨테이너 내부로 복사

### PR 타입

1. [ ] 기능 추가
2. [ ] 기능 삭제
3. [ ] 버그 수정
4. [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항


### 테스트 결과
