### PR TITLE
feat : 영수증 ocr을 이용한 지출 자동등록 기능

### DIFF
--- a/server/src/main/java/com/codemouse/salog/helper/naverOcr/ClovaOcrApiService.java
+++ b/server/src/main/java/com/codemouse/salog/helper/naverOcr/ClovaOcrApiService.java
@@ -1,0 +1,145 @@
+package com.codemouse.salog.helper.naverOcr;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.nimbusds.jose.shaded.json.JSONArray;
+import com.nimbusds.jose.shaded.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.*;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.StreamSupport;
+
+/**
+ * Naver CLOVA OCR API Service (네이버 ocr api 호출)
+ */
+@Service
+public class ClovaOcrApiService {
+    @Value("${naver.ocr.key}")
+    private String secretKey;
+
+    @Value("${naver.ocr.url}")
+    private String apiUrl;
+
+    /**
+     * 네이버 ocr api 호출
+     * Content-Type : application/json
+     * X-OCR-SECRET : {X-OCR-SECRET}
+     */
+    public ClovaOcrDto callOcrApi(String base64Image){
+        ClovaOcrDto parseData = null;
+
+        try {
+            URL url = new URL(apiUrl);
+            HttpURLConnection con = (HttpURLConnection)url.openConnection();
+            con.setUseCaches(false);
+            con.setDoInput(true);
+            con.setDoOutput(true);
+            con.setReadTimeout(30000);
+            con.setRequestMethod("POST");
+            con.setRequestProperty("Content-Type", "application/json; charset=utf-8");
+            con.setRequestProperty("X-OCR-SECRET", secretKey);
+
+            JSONObject json = new JSONObject();
+            json.put("version", "V2");
+            json.put("requestId", UUID.randomUUID().toString());
+            json.put("timestamp", System.currentTimeMillis());
+            JSONObject image = new JSONObject();
+            image.put("format", "jpg"); // 임시 jpg 한정
+            image.put("data", base64Image);
+            image.put("name", "receipt");
+            JSONArray images = new JSONArray();
+            images.add(image);
+            json.put("images", images);
+            String postParams = json.toString();
+
+            // url로 연결 및 json 데이터 입력
+            con.connect();
+            DataOutputStream wr = new DataOutputStream(con.getOutputStream());
+            wr.writeBytes(postParams);
+            wr.flush();
+            wr.close();
+
+            int responseCode = con.getResponseCode();
+            BufferedReader br;
+            if (responseCode == 200) {
+                br = new BufferedReader(new InputStreamReader(con.getInputStream()));
+            } else {
+                br = new BufferedReader(new InputStreamReader(con.getErrorStream()));
+            }
+            String inputLine;
+            StringBuffer response = new StringBuffer();
+            while ((inputLine = br.readLine()) != null) {
+                response.append(inputLine);
+            }
+            br.close();
+
+            // response를 파싱하여 필요한 데이터를 추출
+            String responseJson = response.toString();
+            JsonParser parser = new JsonParser();
+            JsonObject responseObject = parser.parse(responseJson).getAsJsonObject();
+            JsonArray imagesArray = responseObject.getAsJsonArray("images");
+
+            // 각 항목이 null값을 가질 경우에 대한 optional 처리
+            parseData = StreamSupport.stream(imagesArray.spliterator(), false)
+                    .map(JsonElement::getAsJsonObject)
+                    .map(imageObject -> Optional.ofNullable(imageObject.getAsJsonObject("receipt")))
+                    .map(optionalReceipt -> optionalReceipt.map(receipt -> receipt.getAsJsonObject("result")))
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .map(resultObject -> {
+                        String storeInfo = Optional.ofNullable(resultObject.getAsJsonObject("storeInfo"))
+                                .map(storeInfoObj -> storeInfoObj.getAsJsonObject("name"))
+                                .map(nameObj -> nameObj.get("text"))
+                                .map(JsonElement::getAsString)
+                                .orElse("");
+
+                        String paymentDate = Optional.ofNullable(resultObject.getAsJsonObject("paymentInfo"))
+                                .map(paymentInfoObj -> paymentInfoObj.getAsJsonObject("date"))
+                                .map(dateObj -> dateObj.getAsJsonObject("formatted"))
+                                .map(dateFormattedObj -> String.format("%s-%s-%s",
+                                        dateFormattedObj.get("year").getAsString(),
+                                        dateFormattedObj.get("month").getAsString(),
+                                        dateFormattedObj.get("day").getAsString()))
+                                .orElse("");
+
+                        int totalPrice = Optional.ofNullable(resultObject.getAsJsonObject("totalPrice"))
+                                .map(totalPriceObj -> totalPriceObj.getAsJsonObject("price"))
+                                .map(priceObj -> priceObj.getAsJsonObject("formatted"))
+                                .map(formattedObj -> formattedObj.get("value"))
+                                .map(JsonElement::getAsInt)
+                                .orElse(0);
+
+                        return new ClovaOcrDto(paymentDate, totalPrice, storeInfo);
+                    })
+                    .findFirst()
+                    .orElse(new ClovaOcrDto("", 0, ""));    // 스트림이 비어있는 경우 비어있는 객체 반환 null 방지
+
+        } catch (Exception e) {
+            System.out.println(e);
+        }
+
+        return parseData;
+    }
+
+    public String convertImageToBase64(String imageUrl) throws IOException {
+        URL url = new URL(imageUrl);
+        BufferedImage image = ImageIO.read(url);
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ImageIO.write(image, "jpg", bos);   // 임시 jpg 한정
+        byte[] imageBytes = bos.toByteArray();
+        String base64Image = Base64.getEncoder().encodeToString(imageBytes);
+        return base64Image;
+    }
+
+
+}

--- a/server/src/main/java/com/codemouse/salog/helper/naverOcr/ClovaOcrDto.java
+++ b/server/src/main/java/com/codemouse/salog/helper/naverOcr/ClovaOcrDto.java
@@ -1,0 +1,16 @@
+package com.codemouse.salog.helper.naverOcr;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/*
+ocrDto를 따로 생성하고 ocrDto로 받은것을 outgoDto에 옮겨담아줄 것
+WHY? outgo와 ocr 클래스간의 결합도를 낮추기 위함.
+ */
+@AllArgsConstructor
+@Getter
+public class ClovaOcrDto {
+    private String date;
+    private int totalPrice;
+    private String storeInfo;
+}

--- a/server/src/main/java/com/codemouse/salog/ledger/outgo/controller/OutgoController.java
+++ b/server/src/main/java/com/codemouse/salog/ledger/outgo/controller/OutgoController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Positive;
+import java.io.IOException;
 
 @RestController
 @Slf4j
@@ -29,6 +30,13 @@ public class OutgoController {
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
+    @PostMapping("/uploadImage")
+    public ResponseEntity<?> uploadReceiptImage(@RequestHeader(name = "Authorization") String token,
+                                                @Valid @RequestBody OutgoDto.PostImage requestBody) throws IOException {
+        OutgoDto.ImageOcrResponse response = service.convertImageToOutgo(token, requestBody);
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
 
     @PatchMapping("/update/{outgo-id}")
     public ResponseEntity<?> updateOutgo (@RequestHeader(name = "Authorization") String token,

--- a/server/src/main/java/com/codemouse/salog/ledger/outgo/dto/OutgoDto.java
+++ b/server/src/main/java/com/codemouse/salog/ledger/outgo/dto/OutgoDto.java
@@ -3,6 +3,7 @@ package com.codemouse.salog.ledger.outgo.dto;
 import com.codemouse.salog.tags.ledgerTags.dto.LedgerTagDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.*;
 import java.time.LocalDate;
@@ -27,6 +28,13 @@ public class OutgoDto {
         private Boolean wasteList;
     }
 
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    public static class PostImage {
+        private String receiptImageUrl;
+    }
+
     @AllArgsConstructor
     @Getter
     public static class Patch {
@@ -46,7 +54,7 @@ public class OutgoDto {
     @AllArgsConstructor
     @Getter
     public static class Response {
-        private long outgoId;
+        private Long outgoId;
         private LocalDate date;
         private int money;
         private String outgoName;
@@ -54,6 +62,15 @@ public class OutgoDto {
         private String memo;
         private LedgerTagDto.Response outgoTag;
         private boolean wasteList;
+        private String receiptImg;
+    }
+
+    @AllArgsConstructor
+    @Getter
+    public static class ImageOcrResponse {
+        private String date;
+        private int money;
+        private String outgoName;
         private String receiptImg;
     }
 


### PR DESCRIPTION
### PR 타입

1. [x] 기능 추가
2. [ ] 기능 삭제
3. [ ] 버그 수정
4. [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 외부 API : Naver Ocr 을 이용하여 영수증 이미지 url을 입력받아 outgo에 부합하는 데이터를 추출/ 클라이언트로 전달함
- 이미지url을 base64 형태로 인코딩하는 메서드 구현 -> ocr이 base64형의 데이터를 입력받기 때문
- OcrDto 구현 -> 객체별 결합도를 낮추기 위함 
- OutgoController , Dto, Service 에 관련 메서드 구현   

### 테스트 결과
- 양호